### PR TITLE
MTDSA-33442: Fix missing govuk_frontend.js

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ To make changes edit the source files in the `source` folder.
 
 ### Single page output
 
-Although a single page of HTML is generated the markdown is spread across
+Although a single page of HTML is generated, the markdown is spread across
 multiple files to make it easier to manage. They can be found in
 `source/documentation`.
 

--- a/project/AppDependencies.scala
+++ b/project/AppDependencies.scala
@@ -1,8 +1,24 @@
+/*
+ * Copyright 2026 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import sbt.*
 
 object AppDependencies {
 
-  val bootStrapPlayVersion = "10.6.0"
+  val bootStrapPlayVersion = "10.7.0"
 
   val compile: Seq[ModuleID] = Seq(
     "uk.gov.hmrc" %% "bootstrap-frontend-play-30" % bootStrapPlayVersion

--- a/source/javascripts/govuk_frontend.js
+++ b/source/javascripts/govuk_frontend.js
@@ -1,0 +1,1 @@
+//= require govuk_frontend_all

--- a/test/BuildSpec.scala
+++ b/test/BuildSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 HM Revenue & Customs
+ * Copyright 2026 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,14 +16,56 @@
 
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpecLike
-import sys.process._
+
+import java.io.{File, PrintWriter}
+import scala.io.{BufferedSource, Source}
+import scala.language.postfixOps
+import scala.sys.process.*
 
 class BuildSpec extends AnyWordSpecLike with Matchers {
+  val url: String = "/roadmaps/mtd-itsa-vendors-roadmap"
+
+  private def readFileContent(filePath: String): String = {
+    val file: File             = new File(filePath)
+    val source: BufferedSource = Source.fromFile(file, "UTF-8")
+    try source.getLines().mkString("\n")
+    finally source.close()
+  }
+
+  private def updateFileContent(filePath: String, newContent: String): Unit = {
+    val file: File               = new File(filePath)
+    val printWriter: PrintWriter = new PrintWriter(file, "UTF-8")
+    try printWriter.write(newContent)
+    finally printWriter.close()
+  }
+
   "Building the content" should {
     "produce static files" in {
-      val result = "bundle install" #&& Process("bundle exec middleman build --build-dir=public/ --clean", None, "BASE_PATH" -> "/roadmaps/mtd-itsa-vendors-roadmap/") !
+      val result: Int = "bundle install" #&& Process(
+        "bundle exec middleman build --verbose --build-dir=public/ --clean",
+        None,
+        "BASE_PATH" -> s"$url/"
+      ) !
 
       result shouldBe 0
+    }
+  }
+
+  "Modifying the content" should {
+    "update all assets urls in manifest.css to start with the base route" in {
+      val filePath: String        = "public/stylesheets/manifest.css"
+      val originalContent: String = readFileContent(filePath)
+
+      updateFileContent(
+        filePath,
+        originalContent.replace("url(\"", s"url(\"$url")
+      )
+
+      val updatedContent: String = readFileContent(filePath)
+
+      updatedContent should not be originalContent
+
+      updatedContent should include(s"url(\"$url")
     }
   }
 }


### PR DESCRIPTION
[MTDSA-33442](https://jira.tools.tax.service.gov.uk/browse/MTDSA-33442)

<img width="1424" height="902" alt="Fixed govuk_frontend" src="https://github.com/user-attachments/assets/37a3b4cc-6b72-4b86-bf9a-d8760720096f" />

Note that the `tracking.js` is erroring because the request URL `http://localhost:4567/tracking-consent/tracking.js` doesn't exist. When navigating to `https://developer.qa.tax.service.gov.uk/roadmaps/mtd-itsa-vendors-roadmap/index.html#making-tax-digital-for-income-tax-roadmap`, the `tracking.js` returns status 200 because the request URL is `https://developer.qa.tax.service.gov.uk/tracking-consent/tracking.js`